### PR TITLE
consul: add INSANE_SKIP for textrel

### DIFF
--- a/recipes-connectivity/consul/consul_git.bb
+++ b/recipes-connectivity/consul/consul_git.bb
@@ -23,3 +23,6 @@ do_install_append() {
 }
 
 FILES_${PN} += "${systemd_unitdir}/system"
+
+#for i586, executable consul contains textrel
+INSANE_SKIP_${PN} += "textrel"


### PR DESCRIPTION
1. for i586, bitbake consul will have QA error of textrel.
   consul-git-r0 do_package_qa: QA Issue: ELF binary i
   'work/i586-wrs-linux/consul/git-r0/packages-split/consul/usr/bin/consul'
   has relocations in .text [textrel]

   according to go doc:
   -buildmode=pie
   Build the listed main packages and everything they import into
   position independent executables (PIE). Packages not named
   main are ignored.

   checked use command "eu-findtextrel ./consul", functions not
   compiled with -fpic/-fPIC are from packages not named main, and
   also not imported into package main.

   so -buildmode=pie cannot reslove this problem. so refer commit
   b689c72a of oe-core, just skip it.

2. This problem is caused since security_flags.inc is used by default.
   so alternative work around is:
      SECURITY_CFLAGS_pn-consul = "${SECURITY_NOPIE_CFLAGS}"
      SECURITY_CFLAGS_pn-consul = "${SECURITY_NOPIE_CFLAGS}"

Signed-off-by: Changqing Li <changqing.li@windriver.com>